### PR TITLE
Rename severity prop to stage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -94,7 +94,7 @@ class AnnotationIn(BaseModel):
     width: float
     height: float
     type: str
-    severity: str
+    stage: str
     color: str
     created_by: Optional[str] = None
 
@@ -376,7 +376,7 @@ async def export_annotations_pdf(image_id: str):
         for a in anns:
             user = a.get("created_by", "-")
             date_str = a["createdAt"].strftime("%Y-%m-%d %H:%M") if isinstance(a["createdAt"], datetime) else str(a["createdAt"])
-            pdf.cell(0, 8, f'- {a["type"].capitalize()} | Severity: {a["severity"]} | User: {user} | Date: {date_str}', ln=1)
+            pdf.cell(0, 8, f'- {a["type"].capitalize()} | Stage: {a["stage"]} | User: {user} | Date: {date_str}', ln=1)
     else:
         pdf.cell(0, 8, "Aucune annotation.", ln=1)
 

--- a/frontend/src/components/annotation/AnnotationCanvas.tsx
+++ b/frontend/src/components/annotation/AnnotationCanvas.tsx
@@ -33,7 +33,7 @@ const AnnotationCanvas: React.FC<Props> = ({
   const [drawing, setDrawing] = useState(false)
   const [tmp, setTmp] = useState<{ x: number; y: number; w: number; h: number } | null>(null)
   const [type, setType] = useState('hemorrhage')
-  const [severity, setSeverity] = useState<'mild'|'moderate'|'severe'>('mild')
+  const [stage, setStage] = useState<'mild'|'moderate'|'severe'>('mild')
   const stageRef = useRef<any>(null)
 
   useEffect(() => {
@@ -80,8 +80,8 @@ const AnnotationCanvas: React.FC<Props> = ({
       width: nw,
       height: nh,
       type,
-      severity,
-      color: colorFor(severity),
+      stage,
+      color: colorFor(stage),
       createdAt: new Date().toISOString(),
       created_by: user.email // << utiliser l'utilisateur connecté !
     }
@@ -107,7 +107,7 @@ const AnnotationCanvas: React.FC<Props> = ({
               {value:'neovascularization',label:'Neovascularization'},
             ]}
           />
-          <Select label="Severity" value={severity} onChange={e=>setSeverity(e.target.value as any)} className="w-40"
+          <Select label="Stade" value={stage} onChange={e=>setStage(e.target.value as any)} className="w-40"
             options={[
               {value:'mild',label:'Mild'},
               {value:'moderate',label:'Moderate'},
@@ -163,7 +163,7 @@ const AnnotationCanvas: React.FC<Props> = ({
               <Rect
                 x={tmp.x} y={tmp.y}
                 width={tmp.w} height={tmp.h}
-                stroke={colorFor(severity)}
+                stroke={colorFor(stage)}
                 strokeWidth={2}
                 dash={[5,2]}
               />

--- a/frontend/src/components/annotation/AnnotationDetails.tsx
+++ b/frontend/src/components/annotation/AnnotationDetails.tsx
@@ -18,14 +18,14 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
 }) => {
   const { updateAnnotation, deleteAnnotation } = useImageStore();
   const [type, setType] = useState(annotation?.type || '');
-  const [severity, setSeverity] = useState<'mild' | 'moderate' | 'severe'>(
-    (annotation?.severity as 'mild' | 'moderate' | 'severe') || 'mild'
+  const [stage, setStage] = useState<'mild' | 'moderate' | 'severe'>(
+    (annotation?.stage as 'mild' | 'moderate' | 'severe') || 'mild'
   );
 
   React.useEffect(() => {
     if (annotation) {
       setType(annotation.type);
-      setSeverity(annotation.severity);
+      setStage(annotation.stage);
     }
   }, [annotation]);
 
@@ -42,14 +42,14 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
     updateAnnotation(annotation.id, { type: e.target.value });
   };
 
-  const handleSeverityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newSeverity = e.target.value as 'mild' | 'moderate' | 'severe';
-    setSeverity(newSeverity);
-    
-    // Update color based on severity
-    const color = getSeverityColor(newSeverity);
-    updateAnnotation(annotation.id, { 
-      severity: newSeverity,
+  const handleStageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newStage = e.target.value as 'mild' | 'moderate' | 'severe';
+    setStage(newStage);
+
+    // Update color based on stage
+    const color = getStageColor(newStage);
+    updateAnnotation(annotation.id, {
+      stage: newStage,
       color
     });
   };
@@ -58,8 +58,8 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
     deleteAnnotation(annotation.id);
   };
 
-  const getSeverityColor = (severity: string): string => {
-    switch (severity) {
+  const getStageColor = (stage: string): string => {
+    switch (stage) {
       case 'mild':
         return '#FFC107'; // Yellow
       case 'moderate':
@@ -105,9 +105,9 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
           />
           
           <Select
-            label="Severity"
-            value={severity}
-            onChange={handleSeverityChange}
+            label="Stade"
+            value={stage}
+            onChange={handleStageChange}
             options={[
               { value: 'mild', label: 'Mild' },
               { value: 'moderate', label: 'Moderate' },
@@ -135,7 +135,7 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
               Type: {matchingAIAnnotation.type}
             </p>
             <p className="text-sm text-green-700">
-              Severity: {matchingAIAnnotation.severity}
+              Stade: {matchingAIAnnotation.stage}
             </p>
             <p className="text-sm text-green-700">
               Confidence: {(matchingAIAnnotation.confidence * 100).toFixed(1)}%

--- a/frontend/src/components/annotation/AnnotationList.tsx
+++ b/frontend/src/components/annotation/AnnotationList.tsx
@@ -46,7 +46,7 @@ const AnnotationList: React.FC<AnnotationListProps> = ({
               />
               <div>
                 <p className="text-sm font-medium text-gray-900">{annotation.type}</p>
-                <p className="text-xs text-gray-500">Severity: {annotation.severity}</p>
+                <p className="text-xs text-gray-500">Stade: {annotation.stage}</p>
               </div>
             </div>
           </li>

--- a/frontend/src/components/annotation/ClassificationPanel.tsx
+++ b/frontend/src/components/annotation/ClassificationPanel.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 interface Annotation {
   id?: string;
   type?: string;
-  severity?: string;
+  stage?: string;
   position?: { x: number; y: number };
   size?: { width: number; height: number };
   created?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -14,7 +14,7 @@ export type Annotation = {
   width: number
   height: number
   type: string
-  severity: 'mild' | 'moderate' | 'severe'
+  stage: 'mild' | 'moderate' | 'severe'
   color: string
   createdAt: string
   created_by: string
@@ -27,7 +27,7 @@ export type AIAnnotation = {
   width: number
   height: number
   type: string
-  severity: 'mild' | 'moderate' | 'severe'
+  stage: 'mild' | 'moderate' | 'severe'
   confidence: number
   color: string
 }


### PR DESCRIPTION
## Summary
- rename backend `AnnotationIn.severity` field to `stage`
- update PDF export to reference stage
- refactor frontend annotation components to use stage
- change all UI labels from "Severity" to "Stade"

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684994116bb083298f01d49dc35d8567