### PR TITLE
Add annotation update/delete helpers

### DIFF
--- a/frontend/src/components/annotation/AnnotationDetails.tsx
+++ b/frontend/src/components/annotation/AnnotationDetails.tsx
@@ -16,7 +16,8 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
   aiAnnotations,
   showAI,
 }) => {
-  const { updateAnnotation, deleteAnnotation } = useImageStore();
+  const updateAnnotation = useImageStore(s => s.updateAnnotation);
+  const deleteAnnotation = useImageStore(s => s.deleteAnnotation);
   const [type, setType] = useState(annotation?.type || '');
   const [severity, setSeverity] = useState<'mild' | 'moderate' | 'severe'>(
     (annotation?.severity as 'mild' | 'moderate' | 'severe') || 'mild'

--- a/frontend/src/store/imageStore.ts
+++ b/frontend/src/store/imageStore.ts
@@ -15,6 +15,12 @@ interface ImageState {
   /** REPLACES the entire annotation array on the current image */
   updateCurrentAnnotations: (anns: Annotation[]) => void
 
+  /** update a single annotation on the current image */
+  updateAnnotation: (id: string, updates: Partial<Annotation>) => void
+
+  /** delete a single annotation from the current image */
+  deleteAnnotation: (id: string) => void
+
   /** generate and store a global AI prediction */
   generateAIPrediction: () => Promise<void>
 }
@@ -95,6 +101,30 @@ export const useImageStore = create<ImageState>((set, get) => ({
     const cur = get().currentImage
     if (!cur) return
     const updated: RetinalImage = { ...cur, annotations: anns }
+    set(state => ({
+      currentImage: updated,
+      images: state.images.map(i => (i.id === updated.id ? updated : i)),
+    }))
+  },
+
+  updateAnnotation: (id, updates) => {
+    const cur = get().currentImage
+    if (!cur) return
+    const updatedList = cur.annotations.map(a =>
+      a.id === id ? { ...a, ...updates } : a
+    )
+    const updated: RetinalImage = { ...cur, annotations: updatedList }
+    set(state => ({
+      currentImage: updated,
+      images: state.images.map(i => (i.id === updated.id ? updated : i)),
+    }))
+  },
+
+  deleteAnnotation: id => {
+    const cur = get().currentImage
+    if (!cur) return
+    const updatedList = cur.annotations.filter(a => a.id !== id)
+    const updated: RetinalImage = { ...cur, annotations: updatedList }
     set(state => ({
       currentImage: updated,
       images: state.images.map(i => (i.id === updated.id ? updated : i)),


### PR DESCRIPTION
## Summary
- extend image store with `updateAnnotation` and `deleteAnnotation`
- use the new store helpers in `AnnotationDetails`

## Testing
- `npm run lint` *(fails: @eslint/js not found before install; after install shows existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68499427aaa483298632cb21b2db0025