### PR TITLE
Enforce created_by field for annotations

### DIFF
--- a/frontend/src/pages/AnnotationPage.tsx
+++ b/frontend/src/pages/AnnotationPage.tsx
@@ -44,7 +44,9 @@ const AnnotationPage: React.FC = () => {
     if (!currentImage || !user) return
     setLoadingAnn(true)
     // On récupère QUE les annotations créées par cet user pour cette image
-    fetch(`${API}/api/annotations/${currentImage.id}?created_by=${encodeURIComponent(user.email)}`)
+    fetch(`${API}/api/annotations/${currentImage.id}?created_by=${encodeURIComponent(user.email)}`, {
+      headers: { 'X-User-Role': user.role }
+    })
       .then(r => r.json())
       .then((data: Annotation[]) => setAnnotations(data))
       .catch(console.error)
@@ -69,7 +71,9 @@ const AnnotationPage: React.FC = () => {
   const handleReset = () => {
     if (!currentImage || !user) return
     setLoadingAnn(true)
-    fetch(`${API}/api/annotations/${currentImage.id}?created_by=${encodeURIComponent(user.email)}`)
+    fetch(`${API}/api/annotations/${currentImage.id}?created_by=${encodeURIComponent(user.email)}`, {
+      headers: { 'X-User-Role': user.role }
+    })
       .then(r => r.json())
       .then((data: Annotation[]) => setAnnotations(data))
       .catch(console.error)
@@ -82,7 +86,9 @@ const AnnotationPage: React.FC = () => {
     try {
       // fetch existing (for this user only!)
       const existing: Annotation[] = await fetch(
-        `${API}/api/annotations/${currentImage.id}?created_by=${encodeURIComponent(user.email)}`
+        `${API}/api/annotations/${currentImage.id}?created_by=${encodeURIComponent(user.email)}`, {
+          headers: { 'X-User-Role': user.role }
+        }
       ).then(r => r.json())
       // delete each
       await Promise.all(

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -39,7 +39,9 @@ const DashboardPage: React.FC = () => {
   useEffect(() => {
     if (images.length === 0) return;
     images.forEach(img => {
-      fetch(`${API}/api/annotations/${img.id}`)
+      fetch(`${API}/api/annotations/${img.id}?created_by=${encodeURIComponent(user?.email || '')}`, {
+        headers: { 'X-User-Role': user?.role || '' }
+      })
         .then(res => res.json())
         .then((anns: any[]) => {
           setAnnotationCounts(prev => ({


### PR DESCRIPTION
## Summary
- make `created_by` mandatory in the AnnotationIn model
- reject annotation creation if `created_by` is missing
- restrict GET /api/annotations/{imageId} to admins when `created_by` is absent
- frontend always passes `created_by` and user role when fetching annotations

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849ec7fba208329a9a5e5fb560aee07