### PR TITLE
Update image store to handle uploadedBy

### DIFF
--- a/frontend/src/store/imageStore.ts
+++ b/frontend/src/store/imageStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand'
 import { RetinalImage, Annotation, AIAnnotation, AIPrediction } from '../types'
+import { useAuthStore } from './authStore'
 
 interface ImageState {
   images: RetinalImage[]
@@ -58,6 +59,10 @@ export const useImageStore = create<ImageState>((set, get) => ({
       form.append('image', file)
       form.append('patientId', patientId)
       form.append('patientName', patientName)
+      const { user } = useAuthStore.getState()
+      if (user) {
+        form.append('uploadedBy', user.name)
+      }
       const res = await fetch(`${API_BASE}/api/images`, {
         method: 'POST',
         body: form,
@@ -69,7 +74,7 @@ export const useImageStore = create<ImageState>((set, get) => ({
         patientId: doc.patientId,
         patientName: doc.patientName,
         uploadedAt: doc.uploadedAt,
-        uploadedBy: doc.uploadedBy ?? '',
+        uploadedBy: doc.uploadedBy ?? user?.name ?? '',
         annotations: [],
         aiAnnotations: [],
         similarityScore: doc.similarityScore,


### PR DESCRIPTION
## Summary
- send uploadedBy when uploading images and store it when fetching
- rely on auth store to get the current user's name

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed6db6648329b45f4a2ede9319b3