### PR TITLE
Add No DR option with other disease field

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -97,6 +97,7 @@ class AnnotationIn(BaseModel):
     severity: str
     color: str
     created_by: Optional[str] = None
+    other_diseases: Optional[str] = None
 
 class AnnotationOut(AnnotationIn):
     id: str

--- a/frontend/src/components/annotation/AnnotationCanvas.tsx
+++ b/frontend/src/components/annotation/AnnotationCanvas.tsx
@@ -4,6 +4,7 @@ import { Annotation, AIAnnotation, User } from '../../types'
 import { v4 as uuidv4 } from 'uuid'
 import Button from '../ui/Button'
 import Select from '../ui/Select'
+import Input from '../ui/Input'
 
 const CANVAS_WIDTH = 800
 const CANVAS_HEIGHT = 600
@@ -34,6 +35,7 @@ const AnnotationCanvas: React.FC<Props> = ({
   const [tmp, setTmp] = useState<{ x: number; y: number; w: number; h: number } | null>(null)
   const [type, setType] = useState('hemorrhage')
   const [severity, setSeverity] = useState<'mild'|'moderate'|'severe'>('mild')
+  const [otherDiseases, setOtherDiseases] = useState('')
   const stageRef = useRef<any>(null)
 
   useEffect(() => {
@@ -73,6 +75,11 @@ const AnnotationCanvas: React.FC<Props> = ({
     const rx = w<0 ? x+w : x
     const ry = h<0 ? y+h : y
     const nw = Math.abs(w), nh = Math.abs(h)
+    if (type === 'no_dr' && !otherDiseases.trim()) {
+      alert('Please specify other diseases')
+      setTmp(null)
+      return
+    }
     const newA: Annotation = {
       id: uuidv4(),
       x: rx,
@@ -83,10 +90,12 @@ const AnnotationCanvas: React.FC<Props> = ({
       severity,
       color: colorFor(severity),
       createdAt: new Date().toISOString(),
-      created_by: user.email // << utiliser l'utilisateur connecté !
+      created_by: user.email, // << utiliser l'utilisateur connecté !
+      ...(type === 'no_dr' ? { other_diseases: otherDiseases } : {})
     }
     onAnnotationsChange([...annotations, newA])
     setTmp(null)
+    setOtherDiseases('')
   }
 
   return (
@@ -105,15 +114,27 @@ const AnnotationCanvas: React.FC<Props> = ({
               {value:'microaneurysm',label:'Microaneurysm'},
               {value:'exudate',label:'Exudate'},
               {value:'neovascularization',label:'Neovascularization'},
+              {value:'no_dr',label:'No DR'},
             ]}
           />
-          <Select label="Severity" value={severity} onChange={e=>setSeverity(e.target.value as any)} className="w-40"
-            options={[
-              {value:'mild',label:'Mild'},
-              {value:'moderate',label:'Moderate'},
-              {value:'severe',label:'Severe'},
-            ]}
-          />
+          {type !== 'no_dr' && (
+            <Select label="Severity" value={severity} onChange={e=>setSeverity(e.target.value as any)} className="w-40"
+              options={[
+                {value:'mild',label:'Mild'},
+                {value:'moderate',label:'Moderate'},
+                {value:'severe',label:'Severe'},
+              ]}
+            />
+          )}
+          {type === 'no_dr' && (
+            <Input
+              label="Other Diseases"
+              value={otherDiseases}
+              onChange={e => setOtherDiseases(e.target.value)}
+              required
+              className="w-40"
+            />
+          )}
         </div>
       </div>
       <div className="border rounded-lg overflow-hidden bg-gray-100">

--- a/frontend/src/components/annotation/AnnotationDetails.tsx
+++ b/frontend/src/components/annotation/AnnotationDetails.tsx
@@ -3,6 +3,7 @@ import { Annotation, AIAnnotation } from '../../types';
 import { useImageStore } from '../../store/imageStore';
 import Button from '../ui/Button';
 import Select from '../ui/Select';
+import Input from '../ui/Input';
 import { Trash2 } from 'lucide-react';
 
 interface AnnotationDetailsProps {
@@ -21,11 +22,13 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
   const [severity, setSeverity] = useState<'mild' | 'moderate' | 'severe'>(
     (annotation?.severity as 'mild' | 'moderate' | 'severe') || 'mild'
   );
+  const [otherDiseases, setOtherDiseases] = useState(annotation?.other_diseases || '');
 
   React.useEffect(() => {
     if (annotation) {
       setType(annotation.type);
       setSeverity(annotation.severity);
+      setOtherDiseases(annotation.other_diseases || '');
     }
   }, [annotation]);
 
@@ -52,6 +55,11 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
       severity: newSeverity,
       color
     });
+  };
+
+  const handleOtherDiseasesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setOtherDiseases(e.target.value);
+    updateAnnotation(annotation.id, { other_diseases: e.target.value });
   };
 
   const handleDelete = () => {
@@ -101,19 +109,30 @@ const AnnotationDetails: React.FC<AnnotationDetailsProps> = ({
               { value: 'microaneurysm', label: 'Microaneurysm' },
               { value: 'exudate', label: 'Exudate' },
               { value: 'neovascularization', label: 'Neovascularization' },
+              { value: 'no_dr', label: 'No DR' },
             ]}
           />
-          
-          <Select
-            label="Severity"
-            value={severity}
-            onChange={handleSeverityChange}
-            options={[
-              { value: 'mild', label: 'Mild' },
-              { value: 'moderate', label: 'Moderate' },
-              { value: 'severe', label: 'Severe' },
-            ]}
-          />
+
+          {type !== 'no_dr' && (
+            <Select
+              label="Severity"
+              value={severity}
+              onChange={handleSeverityChange}
+              options={[
+                { value: 'mild', label: 'Mild' },
+                { value: 'moderate', label: 'Moderate' },
+                { value: 'severe', label: 'Severe' },
+              ]}
+            />
+          )}
+          {type === 'no_dr' && (
+            <Input
+              label="Other Diseases"
+              value={otherDiseases}
+              onChange={handleOtherDiseasesChange}
+              required
+            />
+          )}
         </div>
         
         <div className="mt-2">

--- a/frontend/src/store/imageStore.ts
+++ b/frontend/src/store/imageStore.ts
@@ -15,6 +15,9 @@ interface ImageState {
   /** REPLACES the entire annotation array on the current image */
   updateCurrentAnnotations: (anns: Annotation[]) => void
 
+  updateAnnotation: (id: string, patch: Partial<Annotation>) => void
+  deleteAnnotation: (id: string) => void
+
   /** generate and store a global AI prediction */
   generateAIPrediction: () => Promise<void>
 }
@@ -95,6 +98,30 @@ export const useImageStore = create<ImageState>((set, get) => ({
     const cur = get().currentImage
     if (!cur) return
     const updated: RetinalImage = { ...cur, annotations: anns }
+    set(state => ({
+      currentImage: updated,
+      images: state.images.map(i => (i.id === updated.id ? updated : i)),
+    }))
+  },
+
+  updateAnnotation: (id, patch) => {
+    const cur = get().currentImage
+    if (!cur) return
+    const anns = cur.annotations.map(a =>
+      a.id === id ? { ...a, ...patch } : a
+    )
+    const updated = { ...cur, annotations: anns }
+    set(state => ({
+      currentImage: updated,
+      images: state.images.map(i => (i.id === updated.id ? updated : i)),
+    }))
+  },
+
+  deleteAnnotation: id => {
+    const cur = get().currentImage
+    if (!cur) return
+    const anns = cur.annotations.filter(a => a.id !== id)
+    const updated = { ...cur, annotations: anns }
     set(state => ({
       currentImage: updated,
       images: state.images.map(i => (i.id === updated.id ? updated : i)),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,7 @@ export type Annotation = {
   color: string
   createdAt: string
   created_by: string
+  other_diseases?: string
 }
 
 export type AIAnnotation = {


### PR DESCRIPTION
## Summary
- extend annotation models with `other_diseases`
- allow creating annotations with a **No DR** type
- hide the stage selector and request `other_diseases` when No DR is chosen
- support editing annotations with this new field
- add update/delete helpers in the image store

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849ee0b971483298074375acb955f8e