### PR TITLE
Update classifications fetch URL

### DIFF
--- a/frontend/src/components/annotation/ClassificationPanel.tsx
+++ b/frontend/src/components/annotation/ClassificationPanel.tsx
@@ -86,7 +86,7 @@ const ClassificationPanel: React.FC<Props> = ({
     };
 
     try {
-      const response = await fetch("http://localhost:8000/classifications", {
+      const response = await fetch(`${API}/api/classifications`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- use the shared `API` base URL when saving classifications

## Testing
- `npm run lint` *(fails: cannot find ESLint module)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849efc923f8832984539c56fd574d7f