### PR TITLE
Add JSON export from canvas

### DIFF
--- a/frontend/src/components/annotation/AnnotationCanvas.tsx
+++ b/frontend/src/components/annotation/AnnotationCanvas.tsx
@@ -4,6 +4,7 @@ import { Annotation, AIAnnotation, User } from '../../types'
 import { v4 as uuidv4 } from 'uuid'
 import Button from '../ui/Button'
 import Select from '../ui/Select'
+import { exportJson } from '../../utils/exportJson'
 
 const CANVAS_WIDTH = 800
 const CANVAS_HEIGHT = 600
@@ -89,6 +90,11 @@ const AnnotationCanvas: React.FC<Props> = ({
     setTmp(null)
   }
 
+  const handleExport = () => {
+    const data = { imageUrl, annotations };
+    exportJson(data, 'annotations_export.json');
+  }
+
   return (
     <div className="flex flex-col">
       {/* contrôles zoom / type / sev */}
@@ -97,6 +103,7 @@ const AnnotationCanvas: React.FC<Props> = ({
           <Button size="sm" onClick={() => setZoom(z=>z*1.2)}>Zoom In</Button>
           <Button size="sm" onClick={() => setZoom(z=>z/1.2)}>Zoom Out</Button>
           <Button size="sm" variant="outline" onClick={() => setZoom(1)}>Reset</Button>
+          <Button size="sm" onClick={handleExport}>Export JSON</Button>
         </div>
         <div className="flex space-x-4">
           <Select label="Anomaly Type" value={type} onChange={e=>setType(e.target.value)} className="w-40"

--- a/frontend/src/components/annotation/ClassificationPanel.tsx
+++ b/frontend/src/components/annotation/ClassificationPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { exportJson } from "../../utils/exportJson";
 
 interface Annotation {
   id?: string;
@@ -57,15 +58,7 @@ const ClassificationPanel: React.FC<Props> = ({
       exported_at: new Date().toISOString(),
     };
 
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `${patientId}_annotations_export.json`;
-    link.click();
-
-    URL.revokeObjectURL(url);
+    exportJson(exportData, `${patientId}_annotations_export.json`);
   };
 
   // Fonction pour sauvegarder en base via l'API FastAPI

--- a/frontend/src/utils/exportJson.ts
+++ b/frontend/src/utils/exportJson.ts
@@ -1,0 +1,9 @@
+export function exportJson(data: any, filename: string) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add shared `exportJson` helper
- reuse helper from `ClassificationPanel`
- add `Export JSON` button to `AnnotationCanvas`

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm test` (fails: Missing script 'test')

------
https://chatgpt.com/codex/tasks/task_e_6849f13d3ff4832994a8f7b15ce1e11b