### PR TITLE
Add uploader badge to image card

### DIFF
--- a/frontend/src/components/dashboard/ImageCard.tsx
+++ b/frontend/src/components/dashboard/ImageCard.tsx
@@ -24,11 +24,17 @@ const ImageCard: React.FC<ImageCardProps> = ({ image, annotationCount }) => {
       />
 
       <div className="p-4">
-        <h3 className="text-lg font-semibold text-gray-900">
-          {image.patientName}
-        </h3>
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">
+            {image.patientName}
+          </h3>
+          {image.uploadedBy && (
+            <span className="bg-gray-200 text-xs px-2 py-0.5 rounded">
+              Dr. {image.uploadedBy}
+            </span>
+          )}
+        </div>
         <p className="text-gray-600">Patient ID: {image.patientId}</p>
-        <p className="text-gray-600">Uploaded by: {image.uploadedBy || '—'}</p>
 
         <div className="mt-4 flex justify-between items-center text-sm text-gray-500">
           <div className="flex items-center">


### PR DESCRIPTION
## Summary
- show uploader badge next to patient name on image cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ac82ad1488329b0445876a659d738