### PR TITLE
Add Excel export option

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.22.3",
         "tailwind-merge": "^2.2.1",
         "uuid": "^11.1.0",
+        "xlsx": "^0.18.5",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -1571,6 +1572,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1804,6 +1814,19 @@
         }
       ]
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1848,6 +1871,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1879,6 +1911,18 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2484,6 +2528,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -3770,6 +3823,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -4202,6 +4267,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4330,6 +4413,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "react-router-dom": "^6.22.3",
     "tailwind-merge": "^2.2.1",
     "uuid": "^11.1.0",
+    "xlsx": "^0.18.5",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/frontend/src/components/annotation/AnnotationCanvas.tsx
+++ b/frontend/src/components/annotation/AnnotationCanvas.tsx
@@ -17,6 +17,7 @@ interface Props {
   onAnnotationsChange: (newAnnots: Annotation[]) => void
   user: User  // <-- add user prop
   onExportJSON: () => void
+  onExportExcel: () => void
   exportDisabled: boolean
 }
 
@@ -29,6 +30,7 @@ const AnnotationCanvas: React.FC<Props> = ({
   onAnnotationsChange,
   user,
   onExportJSON,
+  onExportExcel,
   exportDisabled
 }) => {
   const [img, setImg] = useState<HTMLImageElement | null>(null)
@@ -121,7 +123,10 @@ const AnnotationCanvas: React.FC<Props> = ({
             ]}
           />
         </div>
-        <Button size="sm" onClick={onExportJSON} disabled={exportDisabled} className="ml-auto">Export JSON</Button>
+        <div className="ml-auto space-x-2">
+          <Button size="sm" onClick={onExportJSON} disabled={exportDisabled}>Export JSON</Button>
+          <Button size="sm" onClick={onExportExcel} disabled={exportDisabled}>Export Excel</Button>
+        </div>
       </div>
       <div className="border rounded-lg overflow-hidden bg-gray-100">
         <Stage

--- a/frontend/src/pages/AnnotationPage.tsx
+++ b/frontend/src/pages/AnnotationPage.tsx
@@ -13,6 +13,7 @@ import AnnotationDetails from '../components/annotation/AnnotationDetails'
 import ClassificationPanel from '../components/annotation/ClassificationPanel'
 import Button from '../components/ui/Button'
 import { Annotation, AIPrediction } from '../types'
+import * as XLSX from 'xlsx'
 
 const API = 'http://localhost:8000'
 
@@ -169,6 +170,21 @@ const AnnotationPage: React.FC = () => {
     window.open(`${API}/api/export/pdf/${currentImage.id}`, '_blank')
   }
 
+  // 9) Export Excel
+  const handleExportExcel = () => {
+    if (!currentImage || !user) return
+    const rows = annotations.map(a => ({
+      'Image name': currentImage.url.split('/').pop() ?? currentImage.id,
+      Classification: manualLabel,
+      'Doctor name': user.name,
+      'Annotation date': new Date(a.createdAt).toLocaleDateString(),
+    }))
+    const ws = XLSX.utils.json_to_sheet(rows)
+    const wb = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(wb, ws, 'Annotations')
+    XLSX.writeFile(wb, `${currentImage.patientId}_annotations.xlsx`)
+  }
+
   if (imgLoading || !currentImage || loadingAnn) {
     return (
       <Layout>
@@ -209,6 +225,9 @@ const AnnotationPage: React.FC = () => {
           <Button variant="outline" onClick={handleExportPDF}>
             <FileText className="h-4 w-4 mr-1" /> Export PDF
           </Button>
+          <Button variant="outline" onClick={handleExportExcel}>
+            <FileText className="h-4 w-4 mr-1" /> Export Excel
+          </Button>
         </div>
       </div>
       {/* Main Content */}
@@ -223,6 +242,7 @@ const AnnotationPage: React.FC = () => {
             onAnnotationsChange={handleDrawChange}
             user={user!}
             onExportJSON={handleExportJSON}
+            onExportExcel={handleExportExcel}
             exportDisabled={!manualLabel || (manualLabel !== 'No DR' && stage === '')}
           />
         </div>


### PR DESCRIPTION
## Summary
- add xlsx dependency
- implement Excel export for annotation data
- expose Export Excel button in UI

## Testing
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_684ac8901c1883299f84a68b676b93fc